### PR TITLE
Add ruamel and ruamel.yaml to instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ boar my_recipe.yaml  # this is running a "render" of the recipe
 You will have to install the dependencies of boa, and then execute pip to install:
 
 ```
-mamba install conda-build colorama pip ruamel ruamel.yaml -c conda-forge
+mamba install "conda-build>=3.18.12" colorama pip ruamel ruamel.yaml -c conda-forge
 # now install boa into your prefix with pip
 pip install -e .
 ```

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ boar my_recipe.yaml  # this is running a "render" of the recipe
 You will have to install the dependencies of boa, and then execute pip to install:
 
 ```
-mamba install conda-build colorama pip -c conda-forge
+mamba install conda-build colorama pip ruamel ruamel.yaml -c conda-forge
 # now install boa into your prefix with pip
 pip install -e .
 ```


### PR DESCRIPTION
Add ruamel and ruamel.yaml to installation instructions

Also specifies minimum version for conda-build (3.18.12). Unfortunately there does not seem to be a conda-build>=3.18.12 package for python 3.8.

Closes #9